### PR TITLE
Install versions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.sh text eol=lf

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -146,7 +146,7 @@ install_repo() {
     fi
     CWD=$(pwd)
     if [[ "$CWD" != "*/build" ]]; then
-        ldconfig
+        sudo ldconfig
     fi
     read -p $'\n'"Do you want to build the ${REPOS[$1]} examples [Y/n]? " answer
     case ${answer^^} in

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -6,10 +6,8 @@ then
     cd ${args[0]}
 else
     cd ~
-    args[0]="~"
 fi
-
-ROOT_PATH="rf24libs"
+ROOT_PATH="$(pwd)/rf24libs"
 REPOS=("RF24" "RF24Network" "RF24Mesh" "RF24Gateway")
 DO_INSTALL=("0" "0" "0" "0")
 EXAMPLE_PATH=("examples_linux" "examples_RPi" "examples_RPi" "examples")
@@ -124,7 +122,7 @@ install_repo() {
     then
         git clone https://github.com/nRF24/${REPOS[$1]} $ROOT_PATH/${REPOS[$1]}
     else
-        echo "Using already cloned repo ${args[0]}/$ROOT_PATH/${REPOS[$1]}"
+        echo "Using already cloned repo $ROOT_PATH/${REPOS[$1]}"
     fi
     echo ""
     cd $ROOT_PATH/${REPOS[$1]}
@@ -147,11 +145,8 @@ install_repo() {
         exit 1
     fi
     CWD=$(pwd)
-    if [[ "$CWD" == "*/build" ]]; then
-        cd ../..
-    else
+    if [[ "$CWD" != "*/build" ]]; then
         ldconfig
-        cd ..
     fi
     read -p $'\n'"Do you want to build the ${REPOS[$1]} examples [Y/n]? " answer
     case ${answer^^} in
@@ -172,11 +167,6 @@ install_repo() {
             CWD=$(pwd)
             echo "cd $CWD"
             echo "sudo ./${SUGGESTED_EXAMPLE[$1]}"
-            if [[ "$CWD" == "*/build" ]]; then
-                cd ../../../..
-            else
-                cd ../../..
-            fi;;
     esac
 }
 
@@ -196,28 +186,22 @@ case ${INSTALL_PYRF24^^} in
         then
             git clone https://github.com/nRF24/pyRF24 $ROOT_PATH/pyRF24
         else
-            echo "Using already cloned repo ${args[0]}/$ROOT_PATH/pyRF24"
+            echo "Using already cloned repo $ROOT_PATH/pyRF24"
         fi
         cd $ROOT_PATH/pyRF24
         echo $'\nInitializing frozen submodules\n'
         git submodule update --init
         echo $'\nInstalling build prequisites.\n'
-        python -m pip install -r requirements.txt
-        # endure there are no previous wheels in the dist/ folder
-        if [[ -d "$ROOT_PATH/pyRF24/dist" ]]
-        then
-            rm -r dist/
-        fi
-        echo $'\nInstalling pyrf24 package.\n'
-        python setup.py bdist_wheel
-        python -m pip install dist/pyrf24*.whl
-        cd ../../
+        python3 -m pip install -r requirements.txt
+        echo $'\nInstalling pyrf24 package (from source).\n'
+        # building from src respects the selected $RF24_DRIVER ('pip install pyrf24' strictly uses SPIDEV)
+        python3 -m pip install .
         ;;
 esac
 echo $'\n\n'"*** Installer Complete ***"
 echo "See http://tmrh20.github.io for documentation"
 echo "See http://tmrh20.blogspot.com for info "
-echo $'\n'"Listing repositories in ${args[0]}/$ROOT_PATH"
+echo $'\n'"Listing repositories in $ROOT_PATH"
 ls ${ROOT_PATH}
 
 # clean up env var

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -130,7 +130,7 @@ install_repo() {
     cd $ROOT_PATH/${REPOS[$1]}
     git fetch --all
     git checkout ${BRANCHES[$1]}
-    if [[ -f "CmakeLists.txt" ]]; then
+    if [[ -f "CMakeLists.txt" ]]; then
         create_build_env
         cmake ..
     elif [[ -f "configure" ]]; then
@@ -148,17 +148,17 @@ install_repo() {
     fi
     CWD=$(pwd)
     if [[ "$CWD" == "*/build" ]]; then
-        cd ../../..
+        cd ../..
     else
         ldconfig
-        cd ../..
+        cd ..
     fi
     read -p $'\n'"Do you want to build the ${REPOS[$1]} examples [Y/n]? " answer
     case ${answer^^} in
         N ) ;;
         * )
             cd $ROOT_PATH/${REPOS[$1]}/${EXAMPLE_PATH[$1]}
-            if [[ -f "CmakeLists.txt" ]]; then
+            if [[ -f "CMakeLists.txt" ]]; then
                 create_build_env
                 cmake ..
             fi

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -179,6 +179,7 @@ do
 done
 
 INSTALL_PYRF24="N"
+echo $'\n'
 read -p "Would you like to install the unified python wrapper package (pyrf24) [y/N]?" INSTALL_PYRF24
 case ${INSTALL_PYRF24^^} in
     Y )

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -10,6 +10,7 @@ fi
 ROOT_PATH="$(pwd)/rf24libs"
 REPOS=("RF24" "RF24Network" "RF24Mesh" "RF24Gateway")
 DO_INSTALL=("0" "0" "0" "0")
+CHOOSE_VERSION="N"
 EXAMPLE_PATH=("examples_linux" "examples_RPi" "examples_RPi" "examples")
 SUGGESTED_EXAMPLE=("gettingstarted" "helloworld_tx" "RF24Mesh_Example_Master" "RF24Gateway_ncurses")
 
@@ -39,16 +40,22 @@ then
     sudo apt-get install cmake
 fi
 
+read -p "Choose versions to install (Default: Install latest code from master) [y/N]? " CHOOSE_VERSION
+
 for index in "${!REPOS[@]}"
 do
     read -p "Do you want to install the ${REPOS[index]} library, [y/N]? " answer
     case ${answer^^} in
         Y ) DO_INSTALL[index]=1
-            read -p "Which version/branch of ${REPOS[index]} to install (default is ${BRANCHES[index]})? " version
-            if [[ ${#version} -gt 0 ]]; then
-                BRANCHES[index]=$version
+            if [ "${CHOOSE_VERSION^^}" = "Y" ]
+            then
+                read -p "Which version/branch of ${REPOS[index]} to install (default is ${BRANCHES[index]})? " version
+                if [[ ${#version} -gt 0 ]]; then
+                    BRANCHES[index]=$version
+                fi
             fi
             ;;
+        * ) ;;
     esac
 done
 


### PR DESCRIPTION
Modified the install script to allow specifying a version of the libs to install (defaults to master branch).

This was working about a month ago when I last tried it, but I haven't tried it since the v2.0 release crusade. The error output for installing a v2.0 mesh layer with a v1.x network layer may not be as intuitive as typical pkg managers would output because that would require a bit more comprehensive scripting.