### PR TITLE
switch to clang-format v14

### DIFF
--- a/.github/workflows/cpp_lint.yaml
+++ b/.github/workflows/cpp_lint.yaml
@@ -20,21 +20,24 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      # Ubuntu 22.04 runners no longer ship with clang-format-12
       - name: Install clang-format
-        run: sudo apt-get install clang-format-12
+        run: sudo apt-get install clang-format-17
       - name: Install linter python package
-        run: python3 -m pip install cpp-linter
+        run: python3 -m pip install 'cpp-linter>=1.7.1'
       - name: run linter as a python package
         id: linter
-        run: |
-          cpp-linter \
-          --version=12 \
-          --style=file \
-          --tidy-checks='-*' \
-          --files-changed-only='False' \
-          --extensions=${{ inputs.extensions }} \
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          cpp-linter
+          --version=12
+          --style=file
+          --tidy-checks='-*'
+          --files-changed-only='False'
+          --extensions=${{ inputs.extensions }}
           --ignore='${{ inputs.ignore }}'
+          --format-review=true
+          --file-annotations=false
       - name: Linter checks failed?
         if: steps.linter.outputs.checks-failed > 0
         run: exit 1

--- a/.github/workflows/cpp_lint.yaml
+++ b/.github/workflows/cpp_lint.yaml
@@ -33,7 +33,7 @@ jobs:
           --version=16
           --style=file
           --tidy-checks='-*'
-          --files-changed-only='False'
+          --lines-changed-only=true
           --extensions=${{ inputs.extensions }}
           --ignore='${{ inputs.ignore }}'
           --format-review=true

--- a/.github/workflows/cpp_lint.yaml
+++ b/.github/workflows/cpp_lint.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Install clang-format
-        run: sudo apt-get install clang-format-16
+        run: sudo apt-get install clang-format-14
       - name: Install linter python package
         run: python3 -m pip install 'cpp-linter>=1.7.1'
       - name: run linter as a python package
@@ -30,7 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
           cpp-linter
-          --version=16
+          --version=14
           --style=file
           --tidy-checks='-*'
           --lines-changed-only=true

--- a/.github/workflows/cpp_lint.yaml
+++ b/.github/workflows/cpp_lint.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Install clang-format
-        run: sudo apt-get install clang-format-17
+        run: sudo apt-get install clang-format-16
       - name: Install linter python package
         run: python3 -m pip install 'cpp-linter>=1.7.1'
       - name: run linter as a python package
@@ -30,7 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
           cpp-linter
-          --version=12
+          --version=16
           --style=file
           --tidy-checks='-*'
           --files-changed-only='False'

--- a/C++ Lib and Linux style guide.md
+++ b/C++ Lib and Linux style guide.md
@@ -825,14 +825,6 @@ private:
 
 Do not indent data structures' access modifiers. They should be the same indentation as the structure's definition.
 
-## `ReferenceAlignment: Right`
-
-A reference operator (`&`) should be aligned to the right (immediately preceding the object name).
-
-```cpp
-void myFunc(bool &inputVar) { /* ... */ }
-```
-
 ## `SpacesInLineCommentPrefix: { Maximum: -1, Minimum: 0 }`
 
 Inline comments (beginning with `//`) do not need any mandatory spaces before the comment content. Additionally, there is no maximum space mandated.

--- a/C++ Lib and Linux style guide.md
+++ b/C++ Lib and Linux style guide.md
@@ -804,3 +804,45 @@ Only use spaces (not tabs).
 ## `UseCRLF: false`
 
 This project is primarily for Linux platforms, so we prefer to have LF line endings. We don't use Windows-style CRLF line endings.
+
+## `EmptyLineAfterAccessModifier: Leave`
+
+Allows empty lines after a data structure's access modifiers.
+
+```cpp
+class MyClass {
+    
+public:
+
+    MyClass();
+
+private:
+    _some_private_function();
+};
+```
+
+## `IndentAccessModifiers: false`
+
+Do not indent data structures' access modifiers. They should be the same indentation as the structure's definition.
+
+## `ReferenceAlignment: Right`
+
+A reference operator (`&`) should be aligned to the right (immediately preceding the object name).
+
+```cpp
+void myFunc(bool &inputVar) { /* ... */ }
+```
+
+## `SpacesInLineCommentPrefix: { Maximum: -1, Minimum: 0 }`
+
+Inline comments (beginning with `//`) do not need any mandatory spaces before the comment content. Additionally, there is no maximum space mandated.
+
+## `ShortNamespaceLines: 0`
+
+The number of lines that qualifies a short namespace definition is 0. This is so a closing brace (`}`) for a namespace is always postfixed with a comment that indicates the end of a namespace definition.
+
+```cpp
+namespace a {
+    int foo;
+} // namespace a
+```


### PR DESCRIPTION
Updates reusable CI workflow that checks code formatting.
- uses clang-format v16
- uses bleeding edge of cpp-linter package to field-test the new PR review feature (`cpp-linter --format-review`).

Also updates the guideline explanations as some (useful) options were only applicable to v13+.

> [!NOTE]
> Updates to all nRF24 org repo's .clang-format file is required for consistency.

closes #9 