### PR TITLE
chore(dev): switch to 2bndy5/arduino-compile-sketches

### DIFF
--- a/.github/workflows/build_arduino.yaml
+++ b/.github/workflows/build_arduino.yaml
@@ -85,7 +85,10 @@ jobs:
           echo "report-name=${FQBN}" | tr : - >> "${GITHUB_OUTPUT}"
 
       - name: Compile examples
-        uses: 2bndy5/arduino-compile-sketches@784024f590ca8e61d28f9ffd58902514e9871b96 # v0.1.1
+        uses: 2bndy5/arduino-compile-sketches@7054072856c0b7a908e1df70581ed0421d4d5828 # v0.1.2
+        env:
+          # spell-checker: disable-next-line
+          CLICOLOR_FORCE: 1
         with:
           sketch-paths: ${{ inputs.sketch-paths }}
           fqbn: ${{ inputs.fqbn }}

--- a/.github/workflows/build_arduino.yaml
+++ b/.github/workflows/build_arduino.yaml
@@ -85,9 +85,8 @@ jobs:
           echo "report-name=${FQBN}" | tr : - >> "${GITHUB_OUTPUT}"
 
       - name: Compile examples
-        uses: arduino/compile-sketches@8ac27e99289705c4abec832089575d687b859227 # v1.1.2
+        uses: 2bndy5/arduino-compile-sketches@98a9de69e27638399ed4546e6c0047f4ae4b3177 # v0.1.0
         with:
-          # cli-version: '0.33.0'
           sketch-paths: ${{ inputs.sketch-paths }}
           fqbn: ${{ inputs.fqbn }}
           libraries: ${{ inputs.libraries }}

--- a/.github/workflows/build_arduino.yaml
+++ b/.github/workflows/build_arduino.yaml
@@ -85,7 +85,7 @@ jobs:
           echo "report-name=${FQBN}" | tr : - >> "${GITHUB_OUTPUT}"
 
       - name: Compile examples
-        uses: 2bndy5/arduino-compile-sketches@98a9de69e27638399ed4546e6c0047f4ae4b3177 # v0.1.0
+        uses: 2bndy5/arduino-compile-sketches@784024f590ca8e61d28f9ffd58902514e9871b96 # v0.1.1
         with:
           sketch-paths: ${{ inputs.sketch-paths }}
           fqbn: ${{ inputs.fqbn }}

--- a/.github/workflows/build_arduino.yaml
+++ b/.github/workflows/build_arduino.yaml
@@ -85,7 +85,7 @@ jobs:
           echo "report-name=${FQBN}" | tr : - >> "${GITHUB_OUTPUT}"
 
       - name: Compile examples
-        uses: 2bndy5/arduino-compile-sketches@7054072856c0b7a908e1df70581ed0421d4d5828 # v0.1.2
+        uses: 2bndy5/arduino-compile-sketches@558c3a56bc28ceee3efb0ed83b187f08f4a5d29e # v0.1.3
         env:
           # spell-checker: disable-next-line
           CLICOLOR_FORCE: 1


### PR DESCRIPTION
I'm fairly confident enough to try out [2bndy5/arduino-compile-sketches] now.

This is my rust port of the [arduino/compile-sketches] action where sketches are compiled in parallel (among other QoL improvements).

Should work fine as a drop in replacement. 🤞

[2bndy5/arduino-compile-sketches]: https://github.com/2bndy5/arduino-compile-sketches
[arduino/compile-sketches]: https://github.com/arduino/compile-sketches